### PR TITLE
fix(akita-mat-data-source): fixes pagninator display total count

### DIFF
--- a/src/app/angular-material-demo/angular-material-demo.component.html
+++ b/src/app/angular-material-demo/angular-material-demo.component.html
@@ -6,9 +6,24 @@
       <input matInput placeholder="Placeholder" [(ngModel)]="dataSource.search">
       <mat-icon matSuffix>search</mat-icon>
     </mat-form-field>
+    <mat-slide-toggle (change)="updatePaginator($event)" [checked]="usePaginator">Use pagninator </mat-slide-toggle>
+    <mat-chip-list>
+    <mat-chip *ngFor="let filter of (dataSource.akitaFiltersPlugIn.selectFilters() | async)">
+      {{filter.name}} <mat-icon matChipRemove  (click)="dataSource.removeFilter(filter.id)">cancel</mat-icon>
+    </mat-chip>
+  </mat-chip-list>
+
   </p>
 
+
   <div class="mat-elevation-z8">
+    <div [hidden]="!usePaginator">
+      <mat-paginator #paginator
+                     [pageIndex]="0"
+                     [pageSize]="25"
+                     [pageSizeOptions]="[10, 25, 50, 100, 250]">
+      </mat-paginator>
+    </div>
     <table mat-table class="full-width-table" [dataSource]="dataSource" matSort aria-label="Elements">
       <!-- Id Column -->
       <ng-container matColumnDef="id">
@@ -26,14 +41,8 @@
       <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
 
-    <div [hidden]="!usePaginator">
-      <mat-paginator #paginator
-                     [pageIndex]="0"
-                     [pageSize]="25"
-                     [pageSizeOptions]="[10, 25, 50, 100, 250]">
-      </mat-paginator>
-    </div>
-    <mat-slide-toggle (change)="updatePaginator($event)" [checked]="usePaginator">Use pagninator </mat-slide-toggle>
+
+
   </div>
 </div>
 

--- a/src/app/angular-material-demo/angular-material-demo.component.ts
+++ b/src/app/angular-material-demo/angular-material-demo.component.ts
@@ -11,7 +11,7 @@ import { MatSort } from '@angular/material/sort';
   styleUrls: ['./angular-material-demo.component.scss'],
   encapsulation: ViewEncapsulation.None
 })
-export class AngularMaterialDemoComponent implements OnInit, AfterViewInit {
+export class AngularMaterialDemoComponent implements OnInit {
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
   @ViewChild(MatSort, { static: true }) sort: MatSort;
   dataSource: AkitaMatDataSource<ProductPlant, ProductPlantState>;
@@ -24,6 +24,8 @@ export class AngularMaterialDemoComponent implements OnInit, AfterViewInit {
   ngOnInit(): void {
     this.dataSource = new AkitaMatDataSource<ProductPlant, ProductPlantState>(this.productsQuery, this.productsService.filtersProduct);
     this.productsService.get().subscribe();
+    this.dataSource.paginator = this.paginator;
+    this.dataSource.sort = this.sort;
   }
 
   constructor(
@@ -31,13 +33,11 @@ export class AngularMaterialDemoComponent implements OnInit, AfterViewInit {
     private cartService: CartService,
     private productsQuery: ProductsFiltersQuery) {}
 
-  ngAfterViewInit(): void {
-    this.dataSource.paginator = this.paginator;
-    this.dataSource.sort = this.sort;
-  }
 
   updatePaginator($event) {
     this.usePaginator = $event.checked;
     this.dataSource.paginator = (this.usePaginator)? this.paginator : null;
   }
+
+
 }

--- a/src/app/angular-material-demo/angular-material-demo.module.ts
+++ b/src/app/angular-material-demo/angular-material-demo.module.ts
@@ -11,6 +11,7 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatIconModule} from '@angular/material/icon';
 import {MatSlideToggleModule} from "@angular/material/slide-toggle";
+import {MatChipsModule} from "@angular/material/chips";
 
 const routes: Routes = [
   {
@@ -31,7 +32,8 @@ const routes: Routes = [
         MatInputModule,
         MatIconModule,
         FormsModule,
-        MatSlideToggleModule
+        MatSlideToggleModule,
+        MatChipsModule
     ]
 })
 export class AngularMaterialDemoModule { }


### PR DESCRIPTION
Paginator Record Total not showing on Material Data table with AkitaDataSource when changing pages, and filters was updated externaly, when come back to the page, the paginator display total as 0. Correct this bug.
fixes #8