### PR TITLE
fix(akita-filter-plugins): split Akita Filters interface into two types …

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,31 @@ type AkitaFilter: AkitaFilter<EntityState>  = {
  };
 ```
  
- - Id and function were mandatored. (By default, Id will guid(), and default function, will be defaultFilter helpers). 
+ - Id and function were mandatory. (By default, Id will guid(), and default function, will be defaultFilter helpers). 
  
  - But you can set a name, that will be useful to display the filter in the ui. (by default, it will be calculated with ID and value).
  
- - You can set the value, that could be used in your filter function, or retrieve the value for a filter (in ex to init the form filter)
+ - You can set the value, that could be used in your filter function, or retrieve the value for a filter (in example, to init the form filter)
  
  - Or it could be useful, to execute a filter at the begin or the end. (Could be useful to execute simple filter at the beginning, and complex filter like full search at the end)
  
  - hide: true, it will be applied and not displayed in the ui. 
+
+You can also use AkitaFilterLocal or AkitaFilterServer, to specify if a filter is local (that must have a predicate) or server that must have a value, and don't have predicate. 
+
+```typescript
+export interface AkitaFilterLocal<S extends EntityState, E = getEntityType<S>> extends AkitaFilterBase<S, E> {
+  /** The function to apply filters, by default use defaultFilter helpers, that will search the value in the object */
+  predicate: (entity: E, index: number, array: E[] | HashMap<E>, filter: AkitaFilter<S>) => boolean;
+}
+
+export interface AkitaFilterServer<S extends EntityState, E = getEntityType<S>> extends AkitaFilterBase<S, E> {
+  /** If you have enabled server filter, specify witch filters will be call to server, default to false. */
+  server: true;
+  /** The filter value will be sent to withServer function */
+  value: any;
+}
+```
  
 
 # AkitaFilterPlugins API

--- a/projects/akita-filters-plugin/src/lib/akita-filters-query.ts
+++ b/projects/akita-filters-plugin/src/lib/akita-filters-query.ts
@@ -1,5 +1,6 @@
-import { AkitaFilter, FiltersState, AkitaFiltersStore } from './akita-filters-store';
+import { FiltersState, AkitaFiltersStore } from './akita-filters-store';
 import {EntityState, getEntityType, Order, QueryConfig, QueryEntity} from '@datorama/akita';
+import {AkitaFilter} from './akita-filters.model';
 
 
 @QueryConfig({

--- a/projects/akita-filters-plugin/src/lib/akita-filters-store.ts
+++ b/projects/akita-filters-plugin/src/lib/akita-filters-store.ts
@@ -1,41 +1,5 @@
-import {EntityState, EntityStore, getEntityType, guid, HashMap, ID, SortByOptions, StoreConfig} from '@datorama/akita';
-import {defaultFilter} from './filters-utils';
-
-function capitalize(str: string): string {
-  return str.charAt(0).toUpperCase() + str.substr(1);
-}
-
-export interface AkitaFilter<S extends EntityState, E = getEntityType<S>> {
-  id: ID;
-  /** A corresponding name for display the filter, by default, it will be ${id): ${value}  */
-  name?: string;
-  /** set the order for filter, by default, it is 10 */
-  order?: number;
-  /** The filter value, this will be used to compute name, or getting the current value, to initiate your form */
-  value?: any;
-  /** If you want to have filter that is not displayed on the list */
-  hide?: boolean;
-  /** If you have enabled server filter, specify witch filters will be call to server, default to false. */
-  server?: boolean;
-  /** The function to apply filters, by default use defaultFilter helpers, that will search the value in the object */
-  predicate: ( entity: E, index: number, array: E[] | HashMap<E>, filter: AkitaFilter<S> ) => boolean;
-  /** add any other data you want to add **/
-  [key: string]: any;
-}
-
-export function createFilter<S extends EntityState, E = getEntityType<S>>( filterParams: Partial<AkitaFilter<S, E>> ) {
-  const id = filterParams.id ? filterParams.id : guid();
-  const name = filterParams.name || (filterParams.value && filterParams.id ?
-    `${capitalize(filterParams.id.toString())}: ${filterParams.value.toString()}` : undefined);
-
-  if ( !filterParams.predicate && filterParams.value ) {
-    /** use default function, if not provided */
-    // @ts-ignore
-    filterParams.predicate = defaultFilter;
-  }
-
-  return { id, name, hide: false, order: 10, server: false, ...filterParams } as AkitaFilter<S>;
-}
+import {EntityState, EntityStore, getEntityType, SortByOptions, StoreConfig} from '@datorama/akita';
+import {AkitaFilter} from './akita-filters.model';
 
 export interface FiltersState<S extends EntityState, E = getEntityType<S>> extends EntityState<AkitaFilter<S, E>> {
   sort: SortByOptions<any>;

--- a/projects/akita-filters-plugin/src/lib/akita-filters.model.ts
+++ b/projects/akita-filters-plugin/src/lib/akita-filters.model.ts
@@ -1,0 +1,52 @@
+import {EntityState, getEntityType, guid, HashMap, ID} from '@datorama/akita';
+import {defaultFilter} from './filters-utils';
+
+function capitalize(str: string): string {
+    return str.charAt(0).toUpperCase() + str.substr(1);
+}
+
+export interface AkitaFilterBase<S extends EntityState, E = getEntityType<S>> {
+    id: ID;
+    /** A corresponding name for display the filter, by default, it will be ${id): ${value}  */
+    name?: string;
+    /** set the order for filter, by default, it is 10 */
+    order?: number;
+    /** If you want to have filter that is not displayed on the list */
+    hide?: boolean;
+    /** The filter value, this will be used to compute name, or getting the current value, to initiate your form */
+    value?: any;
+}
+
+export interface AkitaFilterLocal<S extends EntityState, E = getEntityType<S>> extends AkitaFilterBase<S, E> {
+  /** If you have enabled server filter, specify witch filters will be call to server, default to false. */
+  server?: false;
+  /** The function to apply filters, by default use defaultFilter helpers, that will search the value in the object */
+  predicate: (entity: E, index: number, array: E[] | HashMap<E>, filter: AkitaFilter<S>) => boolean;
+}
+
+export interface AkitaFilterServer<S extends EntityState, E = getEntityType<S>> extends AkitaFilterBase<S, E> {
+  /** If you have enabled server filter, specify witch filters will be call to server, default to false. */
+  server: true;
+  /** The filter value will be sent to withServer function */
+  value: any;
+}
+
+export type AkitaFilter<S extends EntityState, E = getEntityType<S>> = AkitaFilterLocal<S, E> | AkitaFilterServer<S, E> | {
+  /** add any other data you want to add, keep this to get the compatibilities with others versions **/
+  [key: string]: any;
+};
+
+export function createFilter<S extends EntityState, E = getEntityType<S>>
+  (filterParams: Partial<AkitaFilterLocal<S> | AkitaFilterServer<S>>) {
+    const id = filterParams.id ? filterParams.id : guid();
+    const name = filterParams.name || (filterParams.value && filterParams.id ?
+        `${capitalize(filterParams.id.toString())}: ${filterParams.value.toString()}` : undefined);
+
+    if (!(filterParams as AkitaFilterLocal<S>)?.predicate && filterParams.value && !filterParams.server) {
+        /** use default function, if not provided */
+        // @ts-ignore
+        (filterParams as AkitaFilterLocal<S>).predicate = defaultFilter;
+    }
+
+    return {id, name, hide: false, order: 10, server: false, ...filterParams} as AkitaFilter<S>;
+}

--- a/projects/akita-filters-plugin/src/lib/filters-utils.ts
+++ b/projects/akita-filters-plugin/src/lib/filters-utils.ts
@@ -1,6 +1,6 @@
 
 import {isDefined, isString, isObject, HashMap, getEntityType, isArray} from '@datorama/akita';
-import {AkitaFilter} from './akita-filters-store';
+import {AkitaFilter} from './akita-filters.model';
 
 /**
  * Helper function to do a default filter

--- a/projects/akita-filters-plugin/src/lib/index.ts
+++ b/projects/akita-filters-plugin/src/lib/index.ts
@@ -6,3 +6,4 @@ export * from './akita-filters-plugin';
 export * from './akita-filters-query';
 export * from './akita-filters-store';
 export * from './filters-utils';
+export * from './akita-filters.model';

--- a/projects/akita-filters-plugin/src/public_api.ts
+++ b/projects/akita-filters-plugin/src/public_api.ts
@@ -6,3 +6,4 @@ export * from './lib/akita-filters-plugin';
 export * from './lib/akita-filters-query';
 export * from './lib/akita-filters-store';
 export * from './lib/filters-utils';
+export * from './lib/akita-filters.model';

--- a/src/app/products-filters/filters-form/filters-form.component.ts
+++ b/src/app/products-filters/filters-form/filters-form.component.ts
@@ -3,8 +3,8 @@ import { FormControl, FormGroup } from '@angular/forms';
 import { Observable } from 'rxjs';
 import {ProductPlant, ProductPlantState, ProductsFiltersService} from '../state';
 import { untilDestroyed } from 'ngx-take-until-destroy';
-import {AkitaFilter} from '../../../../projects/akita-filters-plugin/src/lib/akita-filters-store';
 import {searchFilter} from '../../../../projects/akita-filters-plugin/src/lib/filters-utils';
+import {AkitaFilter} from '../../../../projects/akita-filters-plugin/src/lib/akita-filters.model';
 
 @Component({
   selector: 'app-filters-form',

--- a/src/app/products-filters/state/products-filters.service.ts
+++ b/src/app/products-filters/state/products-filters.service.ts
@@ -6,8 +6,8 @@ import { tap } from 'rxjs/operators';
 import {empty, Observable} from 'rxjs';
 import { ProductsFiltersQuery } from './products-filters.query';
 import {Order} from '@datorama/akita';
-import {AkitaFilter} from '../../../../projects/akita-filters-plugin/src/lib/akita-filters-store';
 import {AkitaFiltersPlugin} from '../../../../projects/akita-filters-plugin/src/lib/akita-filters-plugin';
+import {AkitaFilter} from '../../../../projects/akita-filters-plugin/src/lib/akita-filters.model';
 
 
 @Injectable({


### PR DESCRIPTION
split Akita Filters interface into two types for Local Filters and Server Filters.

 This makes it possible to distinguish between local filters that must have a predicate function, and those that are server type must have a value, but not a predicate function.